### PR TITLE
Correct number of workers for val_dataset

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -44,7 +44,7 @@ train_dataset_it = torch.utils.data.DataLoader(
 val_dataset = get_dataset(
     args['val_dataset']['name'], args['val_dataset']['kwargs'])
 val_dataset_it = torch.utils.data.DataLoader(
-    val_dataset, batch_size=args['val_dataset']['batch_size'], shuffle=True, drop_last=True, num_workers=args['train_dataset']['workers'], pin_memory=True if args['cuda'] else False)
+    val_dataset, batch_size=args['val_dataset']['batch_size'], shuffle=True, drop_last=True, num_workers=args['val_dataset']['workers'], pin_memory=True if args['cuda'] else False)
 
 
 # set model


### PR DESCRIPTION
A very minor code update [here](https://github.com/davyneven/SpatialEmbeddings/blob/213b5fa9900513818365d98e7db9f2067633d94d/src/train.py#L46) in `train.py`:

Updated  code to correctly read **`num_workers`** from `val_dataset` dictionary:
`val_dataset_it = torch.utils.data.DataLoader(val_dataset, batch_size=args['val_dataset']['batch_size'], shuffle=True, drop_last=True, num_workers=args['val_dataset']['workers'], pin_memory=True if args['cuda'] else False)`